### PR TITLE
Fix console errors in PeoplePage

### DIFF
--- a/src/ContactBook/PeoplePage.js
+++ b/src/ContactBook/PeoplePage.js
@@ -2,9 +2,10 @@ import * as React from 'react'
 import ReactWinJS from 'react-winjs'
 import Calc100PercentMinus from '../Utils/Calc100PercentMinus'
 import ProfilePicture from './ProfilePicture'
+import PropTypes from 'prop-types'
 let WinJS = require('winjs')
 
-export default class PeoplePage extends React.Component {
+class PeoplePage extends React.Component {
 
     constructor (props) {
         super (props)
@@ -15,7 +16,7 @@ export default class PeoplePage extends React.Component {
         }
     }
 
-    personRenderer = ReactWinJS.reactRenderer(function (person) {
+    personRenderer = ReactWinJS.reactRenderer((person) => {
         return (
             <div>
                 <ProfilePicture backgroundUrl={person.data.picture} size={34} />
@@ -24,7 +25,7 @@ export default class PeoplePage extends React.Component {
         )
     })
 
-    groupHeaderRenderer = ReactWinJS.reactRenderer(function (item) {
+    groupHeaderRenderer = ReactWinJS.reactRenderer((item) => {
         return (
             <div>{item.data.title}</div>
         )
@@ -39,8 +40,10 @@ export default class PeoplePage extends React.Component {
     handleSelectionChanged = (eventObject) => {
         let listView = eventObject.currentTarget.winControl
         let indices = listView.selection.getIndices()
-        this.setState({ selectedPeople: indices })
-        this.props.onNavigate(indices.length === 1 && !this.state.selectionMode ? ['people', indices[0]] : ['people'])
+        setTimeout(function () {
+            this.setState({ selectedPeople: indices });
+            this.props.onNavigate(indices.length === 1 && !this.state.selectionMode ? ["people", indices[0]] : ["people"]);
+        }.bind(this), 0)
     }
 
     handleContentAnimating (eventObject) {
@@ -55,7 +58,7 @@ export default class PeoplePage extends React.Component {
         let indices = this.state.selectedPeople
         indices.sort()
         indices.reverse()
-        indices.forEach(function (i) {
+        indices.forEach((i) => {
             people.splice(i, 1)
         })
         this.setState({
@@ -216,3 +219,13 @@ export default class PeoplePage extends React.Component {
         }
     }
 }
+
+PeoplePage.propTypes = {
+    mode: PropTypes.oneOf(["small", "medium", "large"]).isRequired,
+    people: PropTypes.object.isRequired,
+    location: PropTypes.array.isRequired,
+    onNavigate: PropTypes.func.isRequired,
+    changePeople: PropTypes.func.isRequired
+}
+
+export default PeoplePage

--- a/src/ContactBook/PeoplePage.js
+++ b/src/ContactBook/PeoplePage.js
@@ -33,7 +33,7 @@ export default class PeoplePage extends React.Component {
     handleToggleSelectionMode =  () => {
         this.setState({selectionMode: !this.state.selectionMode})
         this.props.onNavigate(["people"])
-        // this.refs.listView.winControl.selection.clear()
+        this.refs.listView.winControl.selection.clear()
     }
 
     handleSelectionChanged = (eventObject) => {


### PR DESCRIPTION
## Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: [Conventional Commit](https://conventionalcommits.org/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

1. #8  The application is returning the following error when opening the detail of a user on a small screen.

``` console
Uncaught TypeError: Cannot read property 'dataSource' of null
```  


2. The users who are chosen in the multiple selections stay selected indefinitely unless a different one is chosen.

## What is the new behavior?

Application works without any problem (does not return an error message in the console when opening a user) and users are deselected correctly.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Close: #8 